### PR TITLE
Fix: invalid host header

### DIFF
--- a/lib/dev.js
+++ b/lib/dev.js
@@ -13,6 +13,7 @@ const devServer = new WebpackDevServer(compiler, {
   compress: true,
   hot: config.hot,
   historyApiFallback: true,
+  disableHostCheck: true,
   stats: {
     colors: true,
     chunks: false


### PR DESCRIPTION
forbid [webpack-dev-server module  check host](https://github.com/webpack/webpack-dev-server/issues/882)


